### PR TITLE
Adding a comment to the README specifying that IBDesignable is not used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ After the package its installed simply open your `Storyboard` or `Interface Buil
 
 Since everything is extension based, `IBLocalizable` should play nice with other libraries or `pods` that you are using.
 
+### Build Performance
+
+Since `IBLocalizable` only uses `IBInspectable` and never `IBDesignable`, your incremental builds will continue to work. (http://www.openradar.me/20690594)
+
 ## Sample Project
 In the `Xcode Project` you can find a sample project of a simple `Login` view controller. All of this is automatically localizable in English and Spanish by just using `IBLocalizable`.
 ### English


### PR DESCRIPTION
This means that build performance won't be sacrificed when using this library.

The first worry I had when I looked at this library was whether build times would be affected. After looking over the code, looks like this won't happen, but think it'd be a good idea to include this in the README so people won't need to do this in the future.
