### PR TITLE
Type 'UIControl' has no member 'State' build error

### DIFF
--- a/IBLocalizable/Views/LocalizableButton.swift
+++ b/IBLocalizable/Views/LocalizableButton.swift
@@ -16,7 +16,7 @@ extension UIButton {
             return self.currentTitle
         }
         set{
-            self.setTitle(newValue, for: UIControl.State())
+            self.setTitle(newValue, for: .normal)
         }
     }
   


### PR DESCRIPTION
Based on this [answer](https://stackoverflow.com/questions/45662507/whats-the-difference-between-uicontrolstate-and-uicontrolstate-normal-when?answertab=active#tab-top) on SO I would like to suggest to update the [LocalizableButton.swift](https://github.com/PiXeL16/IBLocalizable/blob/master/IBLocalizable/Views/LocalizableButton.swift#L19).

`self.setTitle(newValue, for: UIControl.State())` to `self.setTitle(newValue, for: .normal)`

I had a build error _Type 'UIControl' has no member 'State'_ on Xcode 9.4.1, Swift 4.1 and had to change it to make it work